### PR TITLE
make ray and semver dependencies optional

### DIFF
--- a/btrdb/utils/ray.py
+++ b/btrdb/utils/ray.py
@@ -1,11 +1,6 @@
-from functools import partial
-
-import ray
-
-import semver
-
 import btrdb
 from btrdb.conn import BTrDB
+from functools import partial
 
 def register_serializer(conn_str=None, apikey=None, profile=None):
     """
@@ -24,6 +19,15 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
         found in the user's predictive grid credentials file
         `~/.predictivegrid/credentials.yaml`.
     """
+    try:
+        import ray
+    except ImportError:
+        raise ImportError("must pip install ray to register custom serializer")
+    try:
+        import semver
+    except ImportError:
+        raise ImportError("must pip install semver to register custom serializer")
+  
     assert ray.is_initialized(), "Need to call ray.init() before registering custom serializer"
     # TODO: check the version using the 'semver' package?
     ver = semver.VersionInfo.parse(ray.__version__)
@@ -31,7 +35,7 @@ def register_serializer(conn_str=None, apikey=None, profile=None):
         ray.register_custom_serializer(
         BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
     elif ver.major == 1 and ver.minor in range(2, 4):
-    # TODO: check different versions of ray?
+        # TODO: check different versions of ray?
         ray.util.register_serializer(
         BTrDB, serializer=btrdb_serializer, deserializer=partial(btrdb_deserializer, conn_str=conn_str, apikey=apikey, profile=profile))
     else:


### PR DESCRIPTION
I noticed that our builds were failing because I did not have `ray` or `semver` installed and they were added to `btrdb/utils/ray.py` with Gabe's serialization work. I was hesitant to add them as requirements because they are only really necessary when the user is trying to use ray with the bindings, so I added a try/except to throw an exception when a user tries to register a custom serializer but does not have these modules installed.

I'm open to feedback on this, this is just the first thing that came to mind.