### PR TITLE
update build status in docs to show github actions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,8 @@
 Welcome to btrdb docs!
 ======================
 
-.. image:: https://img.shields.io/travis/BTrDB/btrdb-python/master.svg
-    :target: https://travis-ci.org/BTrDB/btrdb-python
+.. image:: https://github.com/PingThingsIO/btrdb-python/actions/workflows/release.yaml/badge.svg
+    :target: https://github.com/PingThingsIO/btrdb-python/actions
 
 .. image:: https://readthedocs.org/projects/btrdb/badge/?version=latest
     :target: https://btrdb.readthedocs.io/en/latest/


### PR DESCRIPTION
This PR updates the build badge at the top of the btrdb-python docs to point to our github actions build. Previously it was pointing to Travis, but we haven't used Travis in at least six months