### PR TITLE
change link to docs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ LICENSE      = "BSD-3-Clause"
 REPOSITORY   = "https://github.com/PingThingsIO/btrdb-python"
 PACKAGE      = "btrdb"
 URL          = "http://btrdb.io/"
-DOCS_URL     = "https://btrdb.readthedocs.io/en/latest/"
+DOCS_URL     = "https://btrdb-python.readthedocs.io/en/latest/"
 
 ## Define the keywords
 KEYWORDS     = ('btrdb', 'berkeley', 'timeseries', 'database', 'bindings' 'gRPC')


### PR DESCRIPTION
This PR changes the link to the new readthedocs page, updates to docs should now get automatically pushed there