### PR TITLE
change path in setup back to old docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ LICENSE      = "BSD-3-Clause"
 REPOSITORY   = "https://github.com/PingThingsIO/btrdb-python"
 PACKAGE      = "btrdb"
 URL          = "http://btrdb.io/"
-DOCS_URL     = "https://btrdb-python.readthedocs.io/en/latest/"
+DOCS_URL     = "https://btrdb.readthedocs.io/en/latest/"
 
 ## Define the keywords
 KEYWORDS     = ('btrdb', 'berkeley', 'timeseries', 'database', 'bindings' 'gRPC')


### PR DESCRIPTION
This PR changes the docs path in setup.py back to the old documentation link. We decided it was best to not change it, and I was able to get access to the old readthedocs.