### PR TITLE
remove bundled certs

### DIFF
--- a/btrdb/conn.py
+++ b/btrdb/conn.py
@@ -18,7 +18,6 @@ Connection related objects for the BTrDB library
 import os
 import re
 import json
-import certifi
 import uuid as uuidlib
 
 import grpc
@@ -67,24 +66,11 @@ class Connection(object):
             # certificates but will fail for custom CA certs. Allow the user
             # to specify a CA bundle via env var to overcome this
             env_bundle = os.getenv("BTRDB_CA_BUNDLE", "")
-
-            # certifi certs are provided as part of this package install
-            # https://github.com/certifi/python-certifi
-            lib_certs = certifi.where()
-
-            ca_bundle = env_bundle
-
-            if ca_bundle == "":
-                ca_bundle = lib_certs
-            try:
-                with open(ca_bundle, "rb") as f:
+            if env_bundle != "":
+                with open(env_bundle, "rb") as f:
                     contents = f.read()
-            except Exception:
-                if env_bundle != "":
-                    # The user has given us something but we can't use it, we need to make noise
-                    raise Exception("BTRDB_CA_BUNDLE(%s) env is defined but could not read file" % ca_bundle)
-                else:
-                    contents = None
+            else:
+                contents = None
 
             if apikey is None:
                 self.channel = grpc.secure_channel(


### PR DESCRIPTION
This stop gap for the LE root cert change seems to no longer be needed,
and we were seeing some weird behavior with including it so lets just
clean it up.