### PR TITLE
Multistream read bench insert bench

### DIFF
--- a/btrdb/endpoint.py
+++ b/btrdb/endpoint.py
@@ -71,7 +71,7 @@ class Endpoint(object):
         )
         for result in self.stub.ArrowMultiValues(params):
             check_proto_stat(result.stat)
-            yield result.arrowBytes, result.versionMajor
+            yield result.arrowBytes, None
 
     @error_handler
     def arrowInsertValues(self, uu: uuid.UUID, values: bytearray, policy: str):

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1837,8 +1837,10 @@ class StreamSetBase(Sequence):
         params = self._params_from_filters()
         versions = self.versions()
         params["uu_list"] = [s.uuid for s in self._streams]
-        params["versions"] = [versions[s.uuid] for s in self._streams]
+        params["version_list"] = [versions[s.uuid] for s in self._streams]
         params["snap_periodNS"] = period_ns
+        # dict.pop(key, default_return_value_if_no_key)
+        _ = params.pop("sampling_frequency", None)
         arr_bytes = self._btrdb.ep.arrowMultiValues(**params)
         # exhausting the generator from above
         bytes_materialized = list(arr_bytes)


### PR DESCRIPTION
* The streamset was passing the incorrect params to the endpoint
* The endpoint does not return a `version` in its response, just `stat` and `arrowBytes`

Params have been updated and a NoneType is passed around to ignore the
lack of version info, which lets us use the same logic for all bytes
decoding.

Added multistream benchmark methods for multistream reads with and without timesnapping.