### PR TITLE
Optimize logging calls

### DIFF
--- a/btrdb/endpoint.py
+++ b/btrdb/endpoint.py
@@ -274,14 +274,19 @@ class Endpoint(object):
 
     @error_handler
     def nearest(self, uu, time, version, backward):
-        logger.debug(f"nearest function params: {uu}\t{time}\t{version}\t{backward}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"nearest function params: {uu}\t{time}\t{version}\t{backward}"
+            )
         params = btrdb_pb2.NearestParams(
             uuid=uu.bytes, time=time, versionMajor=version, backward=backward
         )
-        logger.debug(f"params from nearest: {params}")
-        logger.debug(f"uuid: {uu}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"params from nearest: {params}")
+            logger.debug(f"uuid: {uu}")
         result = self.stub.Nearest(params)
-        logger.debug(f"nearest, results: {result}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"nearest, results: {result}")
         check_proto_stat(result.stat)
         return result.value, result.versionMajor
 


### PR DESCRIPTION
Previously, the debug logging in the api would create the f-strings no matter if logging.DEBUG was the current log level or not.

This can impact the performance, especially for benchmarking.

Now, a cached IS_DEBUG flag is created for the stream operations, and other locations, the logger.isEnabledFor boolean is checked.

Note that in the stream.py, this same function call is only executed once, and the results are cached for the rest of the logic.