### PR TITLE
Converting pandas index takes very long, add in arrow_table.

### DIFF
--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -224,10 +224,7 @@ def arrow_to_dataframe(
         tmp = tmp_table.select(["time", *usable_cols])
     else:
         tmp = tmp_table
-    df = tmp.to_pandas(date_as_object=False, types_mapper=pd.ArrowDtype)
-    df = df.set_index("time")
-    df.index = pd.DatetimeIndex(df.index, tz="UTC")
-    return df
+    return tmp.to_pandas(date_as_object=False, types_mapper=pd.ArrowDtype)
 
 
 def to_dataframe(streamset, columns=None, agg="mean", name_callable=None):
@@ -667,6 +664,8 @@ class StreamSetTransformer(object):
 
     to_polars = to_polars
     arrow_to_polars = arrow_to_polars
+
+    arrow_to_arrow_table = arrow_to_arrow_table
 
     to_csv = to_csv
     to_table = to_table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "btrdb"
-version = "5.30.1"
+version = "5.30.2"
 authors = [
     {name="PingThingsIO", email="support@pingthings.io"},
 ]


### PR DESCRIPTION
Small regression in the arrow_to_dataframe method, trying to set the pandas index as the time column leads to pretty massive slowdowns in performance. A pandas issue, not ours. But for our use cases, we like to use pandas dataframes.

If we need to set the index, we can do that at a different point of the workflow, not when we are getting the data back from arrow. This makes the arrow method appear to be very slow when it is not.
