### PR TITLE
Provide option to sort the arrow tables

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1050,7 +1050,7 @@ class Stream(object):
         start: int,
         end: int,
         pointwidth: int,
-        sorted: bool = False,
+        sort_time: bool = False,
         version: int = 0,
         auto_retry=False,
         retries=5,
@@ -1083,7 +1083,7 @@ class Stream(object):
             :func:`btrdb.utils.timez.to_nanoseconds` for valid input types)
         pointwidth : int, required
             Specify the number of ns between data points (2**pointwidth)
-        sorted : bool, default: False
+        sort_time : bool, default: False
             Should the table be sorted on the 'time' column?
         version : int, default: 0
             Version of the stream to query
@@ -1127,7 +1127,7 @@ class Stream(object):
         )
         if len(tables) > 0:
             tabs, ver = zip(*tables)
-            if sorted:
+            if sort_time:
                 return pa.concat_tables(tabs).sort_by("time")
             else:
                 return pa.concat_tables(tabs)
@@ -1224,7 +1224,7 @@ class Stream(object):
         start: int,
         end: int,
         width: int,
-        sorted: bool = False,
+        sort_time: bool = False,
         version: int = 0,
         auto_retry=False,
         retries=5,
@@ -1243,7 +1243,7 @@ class Stream(object):
             :func:`btrdb.utils.timez.to_nanoseconds` for valid input types)
         width : int, required
             The number of nanoseconds in each window.
-        sorted : bool, default: False
+        sort_time : bool, default: False
             Should the table be sorted on the 'time' column.
         version : int, default=0, optional
             The version of the stream to query.
@@ -1295,7 +1295,7 @@ class Stream(object):
         )
         if len(tables) > 0:
             tabs, ver = zip(*tables)
-            if sorted:
+            if sort_time:
                 return pa.concat_tables(tabs).sort_by("time")
             else:
                 return pa.concat_tables(tabs)

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -899,7 +899,6 @@ class Stream(object):
         self,
         start,
         end,
-        sorted: bool = False,
         version: int = 0,
         auto_retry=False,
         retries=5,
@@ -918,8 +917,6 @@ class Stream(object):
         end : int or datetime like object
             The end time in nanoseconds for the range to be queried. (see
             :func:`btrdb.utils.timez.to_nanoseconds` for valid input types)
-        sorted : bool, default: False
-            Should the table be sorted by the 'time' column?
         version: int, default: 0
             The version of the stream to be queried
         auto_retry: bool, default: False
@@ -961,10 +958,7 @@ class Stream(object):
         tables = list(arrow_and_versions)
         if len(tables) > 0:
             tabs, ver = zip(*tables)
-            if sorted:
-                return pa.concat_tables(tabs).sort_by("time")
-            else:
-                return pa.concat_tables(tabs)
+            return pa.concat_tables(tabs)
         else:
             schema = pa.schema(
                 [
@@ -2159,6 +2153,7 @@ class StreamSetBase(Sequence):
                 data = tablex
             else:
                 data = tablex
+            data = data.sort_by("time")
 
         elif self.width is not None and self.depth is not None:
             # create list of stream.windows data (the windows method should
@@ -2189,6 +2184,7 @@ class StreamSetBase(Sequence):
                 data = tablex
             else:
                 data = tablex
+            data = data.sort_by("time")
         else:
             sampling_freq = params.pop("sampling_frequency", 0)
             period_ns = 0
@@ -2211,7 +2207,7 @@ class StreamSetBase(Sequence):
                 data = pa.Table.from_arrays(
                     [pa.array([]) for i in range(1 + len(self._streams))], schema=schema
                 )
-        return data.sort_by("time")
+        return data
 
     def __repr__(self):
         token = "stream" if len(self) == 1 else "streams"


### PR DESCRIPTION
Previously, the arrow endpoints are not guaranteed to present their data in a sorted order, this PR lets the user set that for single stream calls, and sorts by time for the streamset operations by default.

Streamset transformers like `streamset.to_dataframe` in the old version of the api used a `PointBuffer` that would sort the values by time before returning to the user.

The single stream arrow methods now have a boolean argument `sorted` to let the user specify if they want to sort the returned table on the `'time'` column or not.
This is False by default.

The streamset methods though, will be sorted by default and the user wont be able to switch that. We can change that later if needed.