### PR TITLE
Add integration tests to check for misbehaving sampling frequencies.

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1695,7 +1695,7 @@ class StreamSetBase(Sequence):
             key/value pairs for filtering streams based on tags
         annotations : dict
             key/value pairs for filtering streams based on annotations
-        sampling_frequency : int
+        sampling_frequency : float
             The sampling frequency of the data streams in Hz, set this if you want timesnapped values.
 
         Returns
@@ -2257,9 +2257,7 @@ class StreamFilter(object):
     ):
         self.start = to_nanoseconds(start) if start else None
         self.end = to_nanoseconds(end) if end else None
-        self.sampling_frequency = (
-            int(sampling_frequency) if sampling_frequency else None
-        )
+        self.sampling_frequency = sampling_frequency if sampling_frequency else None
 
         if self.start is None and self.end is None:
             raise BTRDBValueError("A valid `start` or `end` must be supplied")

--- a/tests/btrdb_integration/test_streamset.py
+++ b/tests/btrdb_integration/test_streamset.py
@@ -1,4 +1,3 @@
-import logging
 import random
 from math import isnan, nan
 from uuid import uuid4 as new_uuid


### PR DESCRIPTION
`sampling_frequency` in python client api does not correctly sample/align data for frequencies < 1Hz