### PR TITLE
Fix build deprecation warnings in using pyproject.toml and setuptool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ all = [
 ]
 
 [project.urls]
-"Homepage" = "https://btrdb.io"
 "Docs" = "https://btrdb.readthedocs.io"
 "Repository" = "https://github.com/pingthingsio/btrdb-python.git"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ all = [
 ]
 
 [project.urls]
-"Docs" = "https://btrdb.readthedocs.io"
+"Docs" = "https://btrdb-python.readthedocs.io/"
 "Repository" = "https://github.com/pingthingsio/btrdb-python.git"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "5.31.0"
 authors = [
     {name="PingThingsIO", email="support@pingthings.io"},
 ]
+maintainers = [
+    {name="PingThingsIO", email="support@pingthings.io"},
+]
 description = "Bindings to interact with the Berkeley Tree Database using gRPC."
 readme = "README.md"
 license = {file="LICENSE.txt"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
-description-file = DESCRIPTION.md
-license_file = LICENSE.txt
+description_file = DESCRIPTION.md
+license_files = LICENSE.txt
 
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,6 @@ config = {
     "license": LICENSE,
     "author": AUTHOR,
     "author_email": EMAIL,
-    "url": URL,
     "maintainer": MAINTAINER,
     "maintainer_email": EMAIL,
     "project_urls": {

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ LICENSE = "BSD-3-Clause"
 REPOSITORY = "https://github.com/PingThingsIO/btrdb-python"
 PACKAGE = "btrdb"
 URL = "http://btrdb.io/"
-DOCS_URL = "https://btrdb.readthedocs.io/en/latest/"
+DOCS_URL = "https://btrdb-python.readthedocs.io/"
 
 ## Define the keywords
 KEYWORDS = ("btrdb", "berkeley", "timeseries", "database", "bindings" "gRPC")


### PR DESCRIPTION
When doing `pip install --verbose` for the project, we get some deprecation warnings for the build "configuration would be ignored/result in error due to `pyproject.toml` [...] By 2023-Oct-30, you need to update your project and remove deprecated calls or your builds will no longer be supported."

To stick to the PEP standards and the setuptools, this PR attemps to fix that.

Note: we can leave an minimal setup.py if we're using project.toml, see the docs [here](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html). 