### PR TITLE
Remove deprecated columns arg from to_dataframe and arrow_to_dataframe

### DIFF
--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -138,18 +138,13 @@ def arrow_to_series(streamset, agg="mean", name_callable=None):
     return [arrow_df[col] for col in arrow_df]
 
 
-def arrow_to_dataframe(
-    streamset, columns=None, agg=None, name_callable=None
-) -> pd.DataFrame:
+def arrow_to_dataframe(streamset, agg=None, name_callable=None) -> pd.DataFrame:
     """
     Returns a Pandas DataFrame object indexed by time and using the values of a
     stream for each column.
 
     Parameters
     ----------
-    columns: sequence
-        column names to use for DataFrame.  Deprecated and not compatible with name_callable.
-
     agg : List[str], default: ["mean"]
         Specify the StatPoint fields (e.g. aggregating function) to create the dataframe
         from. Must be one or more of "min", "mean", "max", "count", "stddev", or "all". This
@@ -174,13 +169,6 @@ def arrow_to_dataframe(
     except ImportError as err:
         raise ImportError(
             f"Please install Pandas and pyarrow to use this transformation function. ErrorMessage: {err}"
-        )
-    # deprecation warning added in v5.8
-    if columns:
-        warn(
-            "the columns argument is deprecated and will be removed in a future release",
-            DeprecationWarning,
-            stacklevel=2,
         )
 
     if agg is None:
@@ -227,16 +215,13 @@ def arrow_to_dataframe(
     return tmp.to_pandas(date_as_object=False, types_mapper=pd.ArrowDtype)
 
 
-def to_dataframe(streamset, columns=None, agg="mean", name_callable=None):
+def to_dataframe(streamset, agg="mean", name_callable=None):
     """
     Returns a Pandas DataFrame object indexed by time and using the values of a
     stream for each column.
 
     Parameters
     ----------
-    columns: sequence
-        column names to use for DataFrame.  Deprecated and not compatible with name_callable.
-
     agg : str, default: "mean"
         Specify the StatPoint field (e.g. aggregating function) to create the Series
         from. Must be one of "min", "mean", "max", "count", "stddev", or "all". This
@@ -252,14 +237,6 @@ def to_dataframe(streamset, columns=None, agg="mean", name_callable=None):
         import pandas as pd
     except ImportError:
         raise ImportError("Please install Pandas to use this transformation function.")
-
-    # deprecation warning added in v5.8
-    if columns:
-        warn(
-            "the columns argument is deprecated and will be removed in a future release",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     # TODO: allow this at some future point
     if agg == "all" and name_callable is not None:
@@ -288,7 +265,7 @@ def to_dataframe(streamset, columns=None, agg="mean", name_callable=None):
             ]
             df.columns = pd.MultiIndex.from_tuples(stream_names)
         else:
-            df.columns = columns if columns else _stream_names(streamset, name_callable)
+            df.columns = _stream_names(streamset, name_callable)
 
     return df
 

--- a/tests/btrdb/test_transformers.py
+++ b/tests/btrdb/test_transformers.py
@@ -601,7 +601,7 @@ class TestTransformers(object):
 
     def test_to_series_name_lambda(self, streamset):
         """
-        assert to_dateframe uses name lambda
+        assert to_series uses name lambda
         """
         result = streamset.to_series(name_callable=lambda s: s.name)
         assert [s.name for s in result] == ["stream0", "stream1", "stream2", "stream3"]
@@ -691,23 +691,16 @@ class TestTransformers(object):
         df.set_index("time", inplace=True)
         assert to_dataframe(streamset).equals(df)
 
-    def test_to_dataframe_column_issues_warning(self, statpoint_streamset):
+    def test_to_dataframe_column_issues_error(self, statpoint_streamset):
         """
-        assert to_dateframe with column argument issues warning
+        assert to_dateframe with column argument issues error
         """
         columns = ["test/cats", "test/dogs", "test/horses", "test/fishes"]
-        with pytest.deprecated_call():
+        with pytest.raises(TypeError) as unexpected_key_err:
             statpoint_streamset.to_dataframe(columns=columns)
-
-    def test_to_dataframe_column(self, statpoint_streamset):
-        """
-        assert to_dateframe with column argument actually renames columns
-        """
-        columns = ["test/cats", "test/dogs", "test/horses", "test/fishes"]
-        with pytest.deprecated_call():
-            df = statpoint_streamset.to_dataframe(columns=columns)
-
-        assert df.columns.tolist() == columns
+        assert "got an unexpected keyword argument 'columns'" in str(
+            unexpected_key_err.value
+        )
 
     def test_to_dataframe_multindex(self, statpoint_streamset):
         """


### PR DESCRIPTION
The columns arg have been noted to deprecate since v5.8. 
This PR updates both `to_dataframe` and `arrow_to_dataframe` functions as well as relevant tests. 
May not need to test that TypeError stating `columns` was given.