### PR TITLE
bug fix earliest/latest for empty streams

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1604,7 +1604,7 @@ class StreamSetBase(Sequence):
                 earliest.append(point[0])
             else:
                 # add RawPoint with None as timestamp and value
-                earliest.append(RawPoint(None, None))
+                earliest.append(None)
 
         return tuple(earliest)
 
@@ -1635,7 +1635,7 @@ class StreamSetBase(Sequence):
                 latest.append(point[0])
             else:
                 # add RawPoint with None as timestamp and value
-                latest.append(RawPoint(None, None))
+                latest.append(None)
 
         return tuple(latest)
 

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1603,7 +1603,6 @@ class StreamSetBase(Sequence):
             if point is not None:
                 earliest.append(point[0])
             else:
-                # add RawPoint with None as timestamp and value
                 earliest.append(None)
 
         return tuple(earliest)
@@ -1634,7 +1633,6 @@ class StreamSetBase(Sequence):
             if point is not None:
                 latest.append(point[0])
             else:
-                # add RawPoint with None as timestamp and value
                 latest.append(None)
 
         return tuple(latest)

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1602,6 +1602,9 @@ class StreamSetBase(Sequence):
         for point in earliest_points_gen:
             if point is not None:
                 earliest.append(point[0])
+            else:
+                # add RawPoint with None as timestamp and value
+                earliest.append(RawPoint(None, None))
 
         return tuple(earliest)
 
@@ -1630,6 +1633,9 @@ class StreamSetBase(Sequence):
         for point in latest_points_gen:
             if point is not None:
                 latest.append(point[0])
+            else:
+                # add RawPoint with None as timestamp and value
+                latest.append(RawPoint(None, None))
 
         return tuple(latest)
 

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -1599,8 +1599,9 @@ class StreamSetBase(Sequence):
             lambda s: s.nearest(start, version=versions.get(s.uuid, 0), backward=False),
             self._streams,
         )
-        for point, _ in earliest_points_gen:
-            earliest.append(point)
+        for point in earliest_points_gen:
+            if point is not None:
+                earliest.append(point[0])
 
         return tuple(earliest)
 
@@ -1626,8 +1627,9 @@ class StreamSetBase(Sequence):
             lambda s: s.nearest(start, version=versions.get(s.uuid, 0), backward=True),
             self._streams,
         )
-        for point, _ in latest_points_gen:
-            latest.append(point)
+        for point in latest_points_gen:
+            if point is not None:
+                latest.append(point[0])
 
         return tuple(latest)
 


### PR DESCRIPTION
Bug fix:
```
TypeError                                 Traceback (most recent call last)
Cell In[39], line 1
----> 1 streamset.earliest()

File /opt/conda/lib/python3.10/site-packages/btrdb/stream.py:1602, in StreamSetBase.earliest(self)
   1597     logger.debug(f"versions: {versions}")
   1598 earliest_points_gen = self._btrdb._executor.map(
   1599     lambda s: s.nearest(start, version=versions.get(s.uuid, 0), backward=False),
   1600     self._streams,
   1601 )
-> 1602 for point, _ in earliest_points_gen:
   1603     earliest.append(point)
   1605 return tuple(earliest)

TypeError: cannot unpack non-iterable NoneType object
```

and also for latest.