### PR TITLE
Add batching for multistream value requests.

### DIFF
--- a/btrdb/endpoint.py
+++ b/btrdb/endpoint.py
@@ -67,10 +67,10 @@ class Endpoint(object):
     @error_handler
     def arrowMultiValues(self, uu_list, start, end, version_list, snap_periodNS):
         params = btrdb_pb2.ArrowMultiValuesParams(
-            uuid=[uu.bytes for uu in uu_list],
+            uuid=uu_list,
             start=start,
             end=end,
-            versionMajor=[ver for ver in version_list],
+            versionMajor=version_list,
             snapPeriodNs=int(snap_periodNS),
         )
         for result in self.stub.ArrowMultiValues(params):

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -22,24 +22,18 @@ import warnings
 from collections import deque
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 import pyarrow as pa
 
-from btrdb.exceptions import (
-    BTrDBError,
-    BTRDBTypeError,
-    BTRDBValueError,
-    InvalidCollection,
-    InvalidOperation,
-    NoSuchPoint,
-    StreamNotFoundError,
-    retry,
-)
+from btrdb.exceptions import (BTrDBError, BTRDBTypeError, BTRDBValueError,
+                              InvalidCollection, InvalidOperation, NoSuchPoint,
+                              StreamNotFoundError, retry)
 from btrdb.point import RawPoint, StatPoint
 from btrdb.transformers import _STAT_PROPERTIES, StreamSetTransformer
 from btrdb.utils.buffer import PointBuffer
 from btrdb.utils.conversion import AnnotationDecoder, AnnotationEncoder
+from btrdb.utils.general import batched
 from btrdb.utils.general import pointwidth as pw
 from btrdb.utils.timez import currently_as_ns, to_nanoseconds
 
@@ -2197,7 +2191,6 @@ class StreamSetBase(Sequence):
             period_ns = 0
             if sampling_freq > 0:
                 period_ns = _to_period_ns(sampling_freq)
-            from btrdb.utils.general import batched
 
             params["snap_periodNS"] = period_ns
             data = None

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2198,6 +2198,7 @@ class StreamSetBase(Sequence):
             if sampling_freq > 0:
                 period_ns = _to_period_ns(sampling_freq)
             from btrdb.utils.general import batched
+
             params["snap_periodNS"] = period_ns
             data = None
             # Batching the multistream queries is a stop gap to prevent

--- a/btrdb/utils/general.py
+++ b/btrdb/utils/general.py
@@ -13,6 +13,11 @@
 General utilities for btrdb bindings
 """
 
+import itertools
+from typing import Any, Generator
+from collections.abc import Iterable
+
+
 ##########################################################################
 ## Functions
 ##########################################################################
@@ -30,6 +35,17 @@ def unpack_stream_descriptor(desc):
     for ann in desc.annotations:
         anns[ann.key] = ann.val.value
     return tags, anns
+
+
+def batched(iterable: Iterable[Any], n: int) -> Generator[Any, Any, Any]:
+    """
+    Returns a generator the yields tuple batches of data from an iterable
+    """
+    if n < 1:
+        raise ValueError('n must be at least one')
+    my_iter = iter(iterable)
+    while batch := tuple(itertools.islice(my_iter, n)):
+        yield batch
 
 
 ##########################################################################

--- a/btrdb/utils/general.py
+++ b/btrdb/utils/general.py
@@ -14,9 +14,8 @@ General utilities for btrdb bindings
 """
 
 import itertools
-from typing import Any, Generator
 from collections.abc import Iterable
-
+from typing import Any, Generator
 
 ##########################################################################
 ## Functions

--- a/btrdb/utils/general.py
+++ b/btrdb/utils/general.py
@@ -42,7 +42,7 @@ def batched(iterable: Iterable[Any], n: int) -> Generator[Any, Any, Any]:
     Returns a generator the yields tuple batches of data from an iterable
     """
     if n < 1:
-        raise ValueError('n must be at least one')
+        raise ValueError("n must be at least one")
     my_iter = iter(iterable)
     while batch := tuple(itertools.islice(my_iter, n)):
         yield batch


### PR DESCRIPTION
- Add batched method in general utisl
- Add test cases for the function
- Call the batching method on multistream queries
- Join resulting responses into overall table
- Remove some unnecessary list comprehensions

Batching the requests is pretty much always slower so we're setting the batch size quite high here.