### PR TITLE
Update pre-commit versions and add coverage report to gh actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,10 @@ jobs:
         pip install -r tests/requirements.txt
     - name: Test with pytest
       run: |
-        pytest
+        pytest --cov-report= --cov=btrdb # suppress coverage report here
+    - name: Coverage Report
+      run: |
+        coverage report -m
 
 
   release:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
       exclude: ^(setup.cfg|btrdb/grpcinterface)
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 23.12.0
   hooks:
     - id: black-jupyter
       args: [--line-length=88]
       exclude: btrdb/grpcinterface/.*\.py
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.5
+  rev: 5.13.2
   hooks:
     - id: isort
       name: isort (python)
       args: [--profile=black, --line-length=88]
       exclude: btrdb/grpcinterface/.*\.py
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
     args: [--config=setup.cfg]


### PR DESCRIPTION
- Update pre-commit plugin versions.
- turn on coverage report in gh actions checks on PRs