### PR TITLE
Add to_timedelta method for pointwidth class

### DIFF
--- a/btrdb/utils/general.py
+++ b/btrdb/utils/general.py
@@ -12,6 +12,7 @@
 """
 General utilities for btrdb bindings
 """
+from datetime import timedelta
 
 ##########################################################################
 ## Functions
@@ -122,6 +123,12 @@ class pointwidth(object):
 
     def incr(self):
         return pointwidth(self + 1)
+
+    def to_timedelta(self):
+        """
+        Returns the timedelta of the pointwidth.
+        """
+        return timedelta(microseconds=self.microseconds)
 
     def __int__(self):
         return self._pointwidth

--- a/tests/btrdb/utils/test_general.py
+++ b/tests/btrdb/utils/test_general.py
@@ -114,3 +114,19 @@ class TestPointwidth(object):
         Test incrementing a pointwidth
         """
         assert pointwidth(23).incr() == 24
+
+    @pytest.mark.parametrize(
+        "pw, expected",
+        [
+            (54, timedelta(days=208, seconds=43198, microseconds=509482)),
+            (51, timedelta(days=26, seconds=5399, microseconds=813685)),
+            (49, timedelta(days=6, seconds=44549, microseconds=953421)),
+            (46, timedelta(seconds=70368, microseconds=744178)),
+            (43, timedelta(seconds=8796, microseconds=93022)),
+            (39, timedelta(seconds=549, microseconds=755814)),
+            (34, timedelta(seconds=17, microseconds=179869)),
+            (30, timedelta(seconds=1, microseconds=73742)),
+        ],
+    )
+    def test_to_timedelta(self, pw, expected):
+        assert pointwidth(pw).to_timedelta() == expected


### PR DESCRIPTION
Just a helper method to make pointwidth class work with the Arrow table's `time` column dtype of panda.TimeStamp when in dataframe.