### PR TITLE
Update exception handling to support RpcErrors.

### DIFF
--- a/btrdb/exceptions.py
+++ b/btrdb/exceptions.py
@@ -117,18 +117,21 @@ def handle_grpc_error(err):
 
     Parameters
     ----------
-    err: grpc.RpcError
+    err: Union[grpc.RpcError, btrdb.BTrDBError]
     """
     details = err.details()
-    if details == "[404] stream does not exist":
-        raise StreamNotFoundError("Stream not found with provided uuid") from None
-    elif details == "failed to connect to all addresses":
-        raise ConnectionError("Failed to connect to BTrDB") from None
-    elif any(str(e) in err.details() for e in BTRDB_SERVER_ERRORS):
-        raise BTRDBServerError("An error has occured with btrdb-server") from None
-    elif str(err.code()) == "StatusCode.PERMISSION_DENIED":
-        raise PermissionDenied(details) from None
-    raise BTrDBError(details) from None
+    if isinstance(err, BTrDBError):
+        if details == "[404] stream does not exist":
+            raise StreamNotFoundError("Stream not found with provided uuid") from None
+        elif details == "failed to connect to all addresses":
+            raise ConnectionError("Failed to connect to BTrDB") from None
+        elif any(str(e) in err.details() for e in BTRDB_SERVER_ERRORS):
+            raise BTRDBServerError("An error has occured with btrdb-server") from None
+        elif str(err.code()) == "StatusCode.PERMISSION_DENIED":
+            raise PermissionDenied(details) from None
+        raise BTrDBError(details) from None
+    else:
+        raise err
 
 
 def check_proto_stat(stat):


### PR DESCRIPTION
Previously, when we encountered an exception that was either a `BTrDBError` or a `RpcError`, we would then parse both of these exception types as a `btrdberror`, which can lead to confusing error messages when apifrontend is down.

You could get an error like the following:

```
conn.info()
>>> BtrdbError stream removed
```

When this is acually a grpc/rpc error about the connection/stream between the server/client. This can lead folks to thinking that their data `streams` have been deleted, etc.