### PR TITLE
Improve arrow_to_dataframe for large amounts of columns

### DIFF
--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -232,14 +232,16 @@ def arrow_to_dataframe(streamset, agg=None, name_callable=None) -> pd.DataFrame:
     tmp_df.index.name = time_col
     col_names = _stream_names(streamset, name_callable)
     col_names_map = {str(s.uuid): c for s, c in zip(streamset, col_names)}
-    tmp_df = tmp.rename(columns=lambda col_name: _rename(col_name, col_names_map))
+    tmp_df.rename(
+        columns=lambda col_name: _rename(col_name, col_names_map), inplace=True
+    )
     if not streamset.allow_window:
         usable_cols = []
         for column_str in tmp_df.columns:
             for agg_name in agg:
                 if agg_name in column_str:
                     usable_cols.append(column_str)
-        tmp_df = tmp_df.loc[["time"] + usable_cols]
+        tmp_df = tmp_df.loc[:, usable_cols]
 
     return tmp_df
 

--- a/btrdb/transformers.py
+++ b/btrdb/transformers.py
@@ -231,9 +231,12 @@ def arrow_to_dataframe(streamset, agg=None, name_callable=None) -> pd.DataFrame:
         tmp = tmp_table.select([time_col, *usable_cols])
     else:
         tmp = tmp_table
-    tmp_df = tmp.to_pandas(date_as_object=False, types_mapper=pd.ArrowDtype).set_index(
-        time_col
-    )
+    tmp_df = tmp.to_pandas(
+        date_as_object=False,
+        types_mapper=pd.ArrowDtype,
+        split_blocks=True,
+        self_destruct=True,
+    ).set_index(time_col)
     tmp_df.index.name = time_col
     return tmp_df
 


### PR DESCRIPTION
In this PR, improvements for:
- memory usage of converting from arrow Table to pandas [sc-25947]
- for-loops in renaming columns with name_callable (tested for 10k streams, improved from ~26sec to ~16sec 1.6x faster)