### PR TITLE
Test new join

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2430,9 +2430,9 @@ def _merge_pyarrow_tables(stream_map: Dict[uuid.UUID, pa.Table]) -> pa.Table:
     unique_times = _extract_unique_times(stream_map)
     combined_schema = _build_combined_schema(stream_map, unique_times)
 
+    none_data = [None] * len(unique_times)
     preallocated_data = {
-        field.name: pa.array([None] * len(unique_times), type=field.type)
-        for field in combined_schema
+        field.name: pa.array(none_data, type=field.type) for field in combined_schema
     }
     preallocated_data["time"] = unique_times
 

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2382,7 +2382,7 @@ def _build_combined_schema(
     stream_map: Dict[uuid.UUID, pa.Table], unique_times: pa.Array
 ) -> pa.Schema:
     """Constructs a combined schema for the merged table, ensuring unique column names."""
-    combined_schema = pa.schema([("time", unique_times.type)])
+    combined_schema = [("time", unique_times.type)]
     for uu, table in stream_map.items():
         for col_name in table.column_names:
             if col_name != "time":
@@ -2395,7 +2395,7 @@ def _build_combined_schema(
                         else pa.null(),
                     )
                 )
-    return combined_schema
+    return pa.schema(combined_schema)
 
 
 def _fill_table_data(

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2190,22 +2190,6 @@ class StreamSetBase(Sequence):
             table_joined = _merge_pyarrow_tables(
                 {uu: tab for uu, tab in zip(stream_uus, data)}
             )
-            # tablex = data.pop(0)
-            # uu = stream_uus.pop(0)
-            # tab_columns = [
-            #     c if c == "time" else uu + "/" + c for c in tablex.column_names
-            # ]
-            # tablex = tablex.rename_columns(tab_columns)
-            # if data:
-            #     for tab, uu in zip(data, stream_uus):
-            #         tab_columns = [
-            #             c if c == "time" else uu + "/" + c for c in tab.column_names
-            #         ]
-            #         tab = tab.rename_columns(tab_columns)
-            #         tablex = tablex.join(tab, "time", join_type="full outer")
-            #     data = tablex
-            # else:
-            #     data = tablex
             data = table_joined
 
         elif self.width is not None and self.depth is not None:
@@ -2228,23 +2212,6 @@ class StreamSetBase(Sequence):
             table_joined = _merge_pyarrow_tables(
                 {uu: tab for uu, tab in zip(stream_uus, data)}
             )
-            # print(test)
-            # tablex = data.pop(0)
-            # uu = stream_uus.pop(0)
-            # tab_columns = [
-            #     c if c == "time" else uu + "/" + c for c in tablex.column_names
-            # ]
-            # tablex = tablex.rename_columns(tab_columns)
-            # if data:
-            #     for tab, uu in zip(data, stream_uus):
-            #         tab_columns = [
-            #             c if c == "time" else uu + "/" + c for c in tab.column_names
-            #         ]
-            #         tab = tab.rename_columns(tab_columns)
-            #         tablex = tablex.join(tab, "time", join_type="full outer")
-            #     data = tablex
-            # else:
-            #     data = tablex
             data = table_joined
         else:
             sampling_freq = params.pop("sampling_frequency", 0)

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2350,18 +2350,17 @@ def _build_combined_schema(
 ) -> pa.Schema:
     """Constructs a combined schema for the merged table, ensuring unique column names."""
     combined_schema = [("time", unique_times.type)]
-    for uu, table in stream_map.items():
-        for col_name in table.column_names:
-            if col_name != "time":
-                combined_col_name = f"{str(uu)}/{col_name}"
-                combined_schema.append(
-                    pa.field(
-                        combined_col_name,
-                        table.column(col_name).type
-                        if table.num_rows > 0
-                        else pa.null(),
-                    )
-                )
+    # Use a list comprehension to flatten the loop into a single iterable over all columns
+    combined_schema += [
+        pa.field(
+            f"{uu}/{col_name}",
+            table.column(col_name).type if table.num_rows > 0 else pa.null(),
+        )
+        for uu, table in stream_map.items()
+        for col_name in table.column_names
+        if col_name != "time"
+    ]
+
     return pa.schema(combined_schema)
 
 

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2399,13 +2399,15 @@ def _build_combined_schema(
 
 
 def _fill_table_data(
-    table: pa.Table, uu: uuid.UUID, unique_times: pa.Array, combined_schema: pa.Schema
+    table: pa.Table,
+    uu: uuid.UUID,
+    combined_schema: pa.Schema,
+    preallocated_data: dict,
 ) -> Dict[str, pa.Array]:
     """Fills data for a given table based on unique 'time' values."""
-    preallocated_data = {}
     if table.num_rows > 0:
         time_indices = pc.index_in(
-            unique_times, value_set=table.column("time"), skip_nulls=True
+            preallocated_data["time"], value_set=table.column("time"), skip_nulls=True
         )
         for col_name in table.column_names:
             if col_name == "time":
@@ -2420,7 +2422,7 @@ def _fill_table_data(
             if col_name.startswith(f"{str(uu)}/") and col_name not in preallocated_data:
                 field_type = combined_schema.field(col_name).type
                 preallocated_data[col_name] = pa.array(
-                    [None] * len(unique_times), type=field_type
+                    [None] * preallocated_data["time"].length(), type=field_type
                 )
     return preallocated_data
 

--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -2387,7 +2387,7 @@ def _build_combined_schema(
         for col_name in table.column_names:
             if col_name != "time":
                 combined_col_name = f"{str(uu)}/{col_name}"
-                combined_schema = combined_schema.append(
+                combined_schema.append(
                     pa.field(
                         combined_col_name,
                         table.column(col_name).type


### PR DESCRIPTION
When the amount of streams in a streamset grows into the 100s+, the join logic for windows and aligned windows queries became a computational burden due to the join logic in pyarrow for tables only operating on a table at a time.

Since we can just join on the 'time' column,  a simpler approach is to iterate through all windowed data, get a unique sorted list of all timestamps, preallocate a null arrow table for all data with the time column being all the unique sorted timestamps above, and then take all the values that are returned from the windows queries and replace the null entries with their available data. This is needed because aligned windows queries will return an empty table for timeranges where there are no data present, while windows queries will return an entry for every timestamp.

This approach scales well as the number of streams increases in terms of run time, for 1000 streams its approximately 1.75-2x faster than the previous approach.