### PR TITLE
Added a FutureWarning to show deprecation which can't be ignored

### DIFF
--- a/btrdb/conn.py
+++ b/btrdb/conn.py
@@ -24,7 +24,6 @@ import uuid as uuidlib
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Tuple, Union
 from warnings import warn
-import warnings
 
 import certifi
 import grpc
@@ -67,11 +66,11 @@ class Connection(object):
         The ``btrdb.connect`` method is a helper function to make connecting to the platform easier
             usually that will be sufficient for most users.
         """
-        #4 Is a magic number to make sure the error propagates where btrdb.connect is called.
+        # 4 Is a magic number to make sure the error propagates where btrdb.connect is called.
         warn(
             "This API is deprecated in favor of the pingthings_api, refer to your hub landing page for further documentation.",
             FutureWarning,
-            stacklevel=4
+            stacklevel=4,
         )
         addrport = addrportstr.split(":", 2)
         # 100MB size limit ~ 2500 streams for 5000 points with each point being 64bit
@@ -137,7 +136,7 @@ class Connection(object):
                         version = "unknown"
                         try:
                             version = importlib.metadata.version("btrdb")
-                        except:
+                        except Exception:
                             pass
                         metadata.append(
                             (


### PR DESCRIPTION
Deprecated warnings are automatically ignored unless executed in main. While we could use `stacklevel=4` to allow for DeprecationWarning to hit for I presume the majority of people (just running `conn = btrdb.connect(...)` in a notebook it does fail if it is being called from another imported file. So we are instead using FutureWarning (which is the correct warning to use to show deprecations to the user). Though kept stacklevel 4 so it will always show the warning on `conn = btrdb.connect(...)`