### PR TITLE
Fix Redundant Tag Sending

### DIFF
--- a/btrdb/stream.py
+++ b/btrdb/stream.py
@@ -823,7 +823,7 @@ class Stream(object):
         """
         :meta private:
         """
-        tags = self.tags() if tags is None else tags
+        tags = {} if tags is None else tags
         collection = self.collection if collection is None else collection
         if collection is None:
             raise BTRDBValueError(

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -272,15 +272,14 @@ class TestStream(object):
         endpoint = Mock(Endpoint)
         endpoint.streamInfo = Mock(return_value=("koala", 42, {}, {}, None))
         endpoint.info = Mock(return_value={"majorVersion": 5, "minorVersion": 30})
-        stream = Stream(btrdb=BTrDB(endpoint), uuid=uu)
+        stream = Stream(btrdb=BTrDB(endpoint), uuid=uu, property_version=42)
 
         collection = "giraffe"
 
         stream.update(collection=collection)
         stream._btrdb.ep.setStreamTags.assert_called_once_with(
-            uu=uu, expected=None, tags={}, collection=collection
+            uu=uu, expected=42, tags={}, collection=collection
         )
-        stream._btrdb.ep.setStreamAnnotations.assert_not_called()
 
     def test_update_annotations(self):
         """

--- a/tests/btrdb/test_stream.py
+++ b/tests/btrdb/test_stream.py
@@ -278,7 +278,7 @@ class TestStream(object):
 
         stream.update(collection=collection)
         stream._btrdb.ep.setStreamTags.assert_called_once_with(
-            uu=uu, expected=42, tags=stream.tags(), collection=collection
+            uu=uu, expected=None, tags={}, collection=collection
         )
         stream._btrdb.ep.setStreamAnnotations.assert_not_called()
 


### PR DESCRIPTION
Prior when updating tags if the tag field was not set (and for example collection was) we would copy the tags and send them over this was wasteful and with the new metadata schema changes created errors.

This PR alleviates that problem and updates the test to be accurate with the new approach.