### PR TITLE
Tweak error messages in E2E test to match updats in SGS

### DIFF
--- a/tests/btrdb_integration/test_conn.py
+++ b/tests/btrdb_integration/test_conn.py
@@ -24,7 +24,7 @@ class TestConnection:
         env_name = os.getenv("BTRDB_INTEGRATION_TEST_PROFILE")
         creds = credentials_by_profile(env_name)
         conn_str = creds["endpoints"]
-        err_msg = r"""Could not connect to the database, error message: <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAUTHENTICATED\n\tdetails = "invalid api key"\n"""
+        err_msg = r"""Could not connect to the database, error message: <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAUTHENTICATED\n\tdetails = "could not validate api key:"""
         with pytest.raises(BTrDBError, match=err_msg):
             conn = btrdb.connect(conn_str=conn_str, apikey="BOGUS_KEY")
 


### PR DESCRIPTION
 * The error messages for some auth/session-related errors were changed to be more consistent with others (https://github.com/PingThingsIO/smartgridstore/pull/4214) so that the frontend can use existing matching logic to determine that they're auth/session errors.  Some tests here assert on the exact string, so they need to be updated to match.
 * Currently the backend CI is pinned to read from this branch.  That will have to be unpinned once this PR is merged.