### PR TITLE
Pinned pytest to version 8 to keep tests running for the time being

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -34,7 +34,7 @@ protobuf
     #   ray
 pyarrow
     # via btrdb
-pytest
+pytest <9
     # via
     #   btrdb
     #   pytest-cov


### PR DESCRIPTION
Added a maximal version for pytest to unbreak the SGS CI.